### PR TITLE
Write TypeScript code explicitly

### DIFF
--- a/app/head.tsx
+++ b/app/head.tsx
@@ -1,4 +1,4 @@
-export default function Head() {
+export default function Head(): JSX.Element {
   return (
     <>
       <title>Homepage</title>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,12 @@
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function RootLayout(props: Props) {
   return (
     <html lang="en-us">
       <head />
-      <body>{children}</body>
+      <body>{props.children}</body>
     </html>
-  )
+  );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 import "../styles/globals.css";
 import styles from "../styles/Home.module.css";
 
-const home = () => {
+const home = (): JSX.Element => {
   return (
     <>
       <div className={styles.main}>


### PR DESCRIPTION
Just being more explicit while writing TypeScript code.
Example: Use the type JSX.Element explicitly for React components.